### PR TITLE
Add resolving dependency values by it's types, not parameter names

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,32 @@ asyncio.run(main())
 ```
 
 
+### Resolve dependencies by type
+> It's simple! Use `from_` on type annotation
+
+```python
+from contextlib import ExitStack
+
+from fundi import from_, inject, scan
+
+class Session:
+    """Database session"""
+
+def require_user(_: from_(Session)) -> str:
+    return "user"
+
+
+def application(session: from_(Session), user: str = from_(require_user)):
+    print(f"Application started with {user = }")
+    print(f"{session = }")
+
+
+with ExitStack() as stack:
+    inject({"db": Session()}, scan(application), stack)
+```
+> Note: while resolving dependencies by type parameter names doesn't really matter.
+
+
 ### Utilities
 
 - `fundi.order` - returns order in which dependencies will be resolved

--- a/fundi/__init__.py
+++ b/fundi/__init__.py
@@ -1,16 +1,6 @@
-import typing
-
 from .scan import scan
+from .from_ import from_
 from .resolve import resolve
 from .util import tree, order
-from .types import CallableInfo
 from .inject import inject, ainject
-
-
-def from_(call: typing.Callable[..., typing.Any]) -> CallableInfo:
-    """
-    Use callable as dependency for parameter of function(alias for fundi.scan.scan)
-    :param call: callable to be used as dependency
-    :return: callable information
-    """
-    return scan(call)
+from .types import CallableInfo, TypeResolver

--- a/fundi/from_.py
+++ b/fundi/from_.py
@@ -1,0 +1,21 @@
+import typing
+
+from fundi.scan import scan
+from fundi.types import CallableInfo, TypeResolver
+
+
+def from_(dependency: type | typing.Callable[..., typing.Any]) -> TypeResolver | CallableInfo:
+    """
+    Use callable or type as dependency for parameter of function
+
+    if dependency parameter is callable the ``fundi.scan.scan`` is used
+
+    if dependency parameter is type the ``fundi.types.TypeResolver`` is returned
+
+    :param dependency: function dependency
+    :return: callable information
+    """
+    if isinstance(dependency, type):
+        return TypeResolver(dependency)
+
+    return scan(dependency)

--- a/fundi/from_.pyi
+++ b/fundi/from_.pyi
@@ -1,0 +1,11 @@
+import typing
+from typing import overload
+
+from fundi.types import CallableInfo
+
+T = typing.TypeVar("T")
+
+@overload
+def from_(dependency: type[T]) -> type[T]: ...
+@overload
+def from_(dependency: typing.Callable[..., typing.Any]) -> CallableInfo: ...

--- a/fundi/scan.py
+++ b/fundi/scan.py
@@ -1,7 +1,7 @@
 import typing
 import inspect
 
-from fundi.types import R, CallableInfo, Parameter
+from fundi.types import R, CallableInfo, Parameter, TypeResolver
 
 
 def scan(call: typing.Callable[..., R]) -> CallableInfo[R]:
@@ -19,13 +19,18 @@ def scan(call: typing.Callable[..., R]) -> CallableInfo[R]:
 
         has_default = param.default is not inspect.Parameter.empty
 
+        annotation: type = param.annotation
+        if isinstance(annotation, TypeResolver):
+            annotation = annotation.annotation
+
         params.append(
             Parameter(
                 param.name,
-                param.annotation,
+                annotation,
                 from_=None,
                 default=param.default if has_default else None,
                 has_default=has_default,
+                resolve_by_type=isinstance(param.annotation, TypeResolver),
             )
         )
 

--- a/fundi/types.py
+++ b/fundi/types.py
@@ -1,9 +1,20 @@
 import typing
 from dataclasses import dataclass
 
-__all__ = ["R", "Parameter", "CallableInfo", "ParameterResult"]
+__all__ = ["R", "TypeResolver", "Parameter", "CallableInfo", "ParameterResult"]
 
 R = typing.TypeVar("R")
+
+
+@dataclass
+class TypeResolver:
+    """
+    Mark that tells ``fundi.scan.scan`` to set ``Parameter.resolve_by_type`` to True.
+
+    This changes logic of ``fundi.resolve.resolve``, so it uses ``Parameter.annotation``
+    to find value in scope instead of ``Parameter.name``
+    """
+    annotation: type
 
 
 @dataclass
@@ -13,6 +24,7 @@ class Parameter:
     from_: "CallableInfo | None"
     default: typing.Any = None
     has_default: bool = False
+    resolve_by_type: bool = False
 
 
 @dataclass

--- a/tests/util/test_resolve.py
+++ b/tests/util/test_resolve.py
@@ -43,3 +43,29 @@ def test_resolve_async():
 
             if result.parameter_name == "arg":
                 assert result.value == 1
+
+
+def test_resolve_by_type():
+    class EventHandler:
+        pass
+
+    def dep():
+        pass
+
+    # Using from_ on type tells resolver that it should search value in scope by type, not parameter name
+    def func(arg: int, arg1: str, handler: from_(EventHandler)):
+        pass
+
+    event_handler = EventHandler()
+
+    for result in resolve({"arg": 1, "arg1": "value", "+1": event_handler}, scan(func), {}):
+        assert result.parameter_name in ("arg", "arg1", "handler")
+
+        if result.parameter_name == "arg1":
+            assert result.value == "value"
+
+        if result.parameter_name == "arg":
+            assert result.value == 1
+
+        if result.parameter_name == "handler":
+            assert result.value is event_handler

--- a/uv.lock
+++ b/uv.lock
@@ -67,7 +67,7 @@ wheels = [
 
 [[package]]
 name = "fundi"
-version = "0.0.2"
+version = "0.0.4"
 source = { virtual = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
Adds possibility to resolve dependency parameter value by it's type, not name.

Implements next syntax:
```python
from contextlib import ExitStack

from fundi import inject, from_, scan


class Session: ...


def require_user(db: from_(Session)): ...


def application(user: str = from_(require_user)): ...


with ExitStack() as stack:
    inject({"session": Session()}, scan(application), stack)
```