### PR TITLE
Lifespan exception awareness

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -9,6 +9,19 @@ resources after data they returned was used
 
 .. literalinclude:: ../examples/lifespan.py
 
+
+Lifespan exception awareness
+============================
+Lifespan dependencies aware about downstream exceptions. This means you can
+catch exception that happened during injection in lifespan dependency to do additional
+cleanup if exception occurred.
+
+  Note: Even that lifespan dependency can catch exception does not mean it can ignore it.
+  FunDI does not allow lifespan dependencies to ignore exceptions. So, exception will be re-raised
+  even if lifespan dependency ignored it.
+
+.. literalinclude:: ../examples/lifespan_exception_awareness.py
+
 Caching
 =======
 FunDI caches dependency results by default — so each dependency is

--- a/docs/howtos/lifespan-dependency.rst
+++ b/docs/howtos/lifespan-dependency.rst
@@ -54,6 +54,18 @@ Asynchronous dependency that does the same:
             file.close()
 
 
+Exception awareness
+===================
+Lifespan dependencies aware about downstream exceptions. This means you can
+catch exception that happened during injection in lifespan dependency to do additional
+cleanup if exception occurred.
+
+  Note: Even that lifespan dependency can catch exception does not mean it can ignore it.
+  FunDI does not allow lifespan dependencies to ignore exceptions. So, exception will be re-raised
+  even if lifespan dependency ignored it.
+
+.. literalinclude:: ../examples/lifespan_exception_awareness.py
+
 When to use lifespan dependencies
 =================================
 - Managing connections

--- a/examples/lifespan_exception_awareness.py
+++ b/examples/lifespan_exception_awareness.py
@@ -1,0 +1,35 @@
+from contextlib import ExitStack
+
+from fundi import from_, scan, inject, injection_trace
+
+
+def lifespan():
+    try:
+        yield
+        print("Injection happened successfully")
+    except ConnectionRefusedError as e:  # <== Lifespan dependency caught exception
+        print("exception happened on teardown:", e)
+        print("injection trace:")
+        trace = injection_trace(e)
+        while trace:
+            print(" ", trace.info.call, "with", trace.values)
+            trace = trace.origin
+
+        print()
+
+
+def require_random_animal(b=from_(lifespan)) -> str:
+    raise ConnectionRefusedError("Cannot connect to random.animal.com")  # <== Exception happened here
+
+
+def application(
+    animal: str = from_(require_random_animal),
+):
+    print("Animal:", animal)
+
+
+try:
+    with ExitStack() as stack:
+        inject({}, scan(application), stack)
+except ConnectionRefusedError:  # <== Lifespan dependency does not reraise exception, but it still goes downstream
+    print("ConnectionRefusedError happened on injection")

--- a/fundi/util.py
+++ b/fundi/util.py
@@ -59,6 +59,12 @@ def _call_sync(
             except StopIteration:
                 # DO NOT ALLOW LIFESPAN DEPENDENCIES TO IGNORE EXCEPTIONS
                 return exc_type is None
+            except exc_type as e:
+                # Do not include re-raise of this exception in traceback to make it cleaner
+                if e is exc_value:
+                    return False
+
+                raise
 
             warnings.warn("Generator not exited", UserWarning)
 
@@ -96,6 +102,12 @@ async def _call_async(
             except StopIteration:
                 # DO NOT ALLOW LIFESPAN DEPENDENCIES TO IGNORE EXCEPTIONS
                 return exc_type is None
+            except exc_type as e:
+                # Do not include re-raise of this exception in traceback to make it cleaner
+                if e is exc_value:
+                    return False
+
+                raise
 
             warnings.warn("Generator not exited", UserWarning)
 

--- a/fundi/util.py
+++ b/fundi/util.py
@@ -1,6 +1,8 @@
 import typing
 import inspect
+import warnings
 from contextlib import AsyncExitStack, ExitStack
+from types import TracebackType
 
 from fundi.resolve import resolve
 from fundi.types import CallableInfo, InjectionTrace
@@ -45,16 +47,25 @@ def _call_sync(
     value = info.call(**values)
 
     if info.generator:
-        generator = value
+        generator: typing.Generator = value
         value = next(generator)
 
-        def exit_generator():
+        def close_generator(exc_type: type[BaseException], exc_value: BaseException, tb: TracebackType) -> bool:
             try:
-                next(generator)
+                if exc_type is not None:
+                    generator.throw(exc_type, exc_value, tb)
+                else:
+                    next(generator)
             except StopIteration:
-                pass
+                # DO NOT ALLOW LIFESPAN DEPENDENCIES TO IGNORE EXCEPTIONS
+                return exc_type is None
 
-        stack.callback(exit_generator)
+            warnings.warn("Generator not exited", UserWarning)
+
+            # DO NOT ALLOW LIFESPAN DEPENDENCIES TO IGNORE EXCEPTIONS
+            return exc_type is None
+
+        stack.push(close_generator)
 
     return value
 
@@ -73,16 +84,25 @@ async def _call_async(
     value = info.call(**values)
 
     if info.generator:
-        generator = value
+        generator: typing.AsyncGenerator = value
         value = await anext(generator)
 
-        async def exit_generator():
+        async def close_generator(exc_type: type[BaseException], exc_value: BaseException, tb: TracebackType) -> bool:
             try:
-                await anext(generator)
-            except StopAsyncIteration:
-                pass
+                if exc_type is not None:
+                    await generator.athrow(exc_type, exc_value, tb)
+                else:
+                    await anext(generator)
+            except StopIteration:
+                # DO NOT ALLOW LIFESPAN DEPENDENCIES TO IGNORE EXCEPTIONS
+                return exc_type is None
 
-        stack.push_async_callback(exit_generator)
+            warnings.warn("Generator not exited", UserWarning)
+
+            # DO NOT ALLOW LIFESPAN DEPENDENCIES TO IGNORE EXCEPTIONS
+            return exc_type is None
+
+        stack.push_async_exit(close_generator)
 
     else:
         value = await value

--- a/fundi/util.py
+++ b/fundi/util.py
@@ -59,7 +59,7 @@ def _call_sync(
             except StopIteration:
                 # DO NOT ALLOW LIFESPAN DEPENDENCIES TO IGNORE EXCEPTIONS
                 return exc_type is None
-            except exc_type as e:
+            except Exception as e:
                 # Do not include re-raise of this exception in traceback to make it cleaner
                 if e is exc_value:
                     return False
@@ -102,7 +102,7 @@ async def _call_async(
             except StopIteration:
                 # DO NOT ALLOW LIFESPAN DEPENDENCIES TO IGNORE EXCEPTIONS
                 return exc_type is None
-            except exc_type as e:
+            except Exception as e:
                 # Do not include re-raise of this exception in traceback to make it cleaner
                 if e is exc_value:
                     return False

--- a/fundi/util.py
+++ b/fundi/util.py
@@ -99,7 +99,7 @@ async def _call_async(
                     await generator.athrow(exc_type, exc_value, tb)
                 else:
                     await anext(generator)
-            except StopIteration:
+            except StopAsyncIteration:
                 # DO NOT ALLOW LIFESPAN DEPENDENCIES TO IGNORE EXCEPTIONS
                 return exc_type is None
             except Exception as e:


### PR DESCRIPTION
In this PR I've added exception awareness to lifespan dependencies. This ensures that lifespan-dependency can properly act on exceptions. Still, lifespan dependencies CANNOT ignore exceptions. This behavior is made to keep execution flow straightforward.