### PR TITLE
Add configurable_dependency decorator and impove documentation

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -52,3 +52,24 @@ Exception tracing
 FunDI adds injection trace to all exceptions on injection to help you understand them
 
 .. literalinclude:: ../examples/exception_tracing.py
+
+
+Configurable dependencies
+=========================
+FunDI supports configurable dependencies - functions that return dependencies with different behavior
+based on provided arguments to them:
+
+.. literalinclude:: ../examples/configurable_dependency.py
+
+..
+
+  Note: :code:`configurable_dependency` decorator is optional, but it caches dependencies,
+  so their results can be cached on injection.
+
+
+Composite dependencies
+======================
+Composite dependencies - special kind of configurable dependency that accepts other
+dependencies as parameters
+
+.. literalinclude:: ../examples/composite_dependency.py

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -66,6 +66,9 @@ based on provided arguments to them:
   Note: :code:`configurable_dependency` decorator is optional, but it caches dependencies,
   so their results can be cached on injection.
 
+  Also, :code:`configurable_dependency` decorator does not cache dependencies configured with mutable arguments.
+
+
 
 Composite dependencies
 ======================

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -11,3 +11,5 @@ API Reference
 .. autofunction :: fundi.ainject
 
 .. autofunction :: fundi.resolve
+
+.. autofunction :: fundi.configurable_dependency

--- a/docs/howtos/configurable-dependency.rst
+++ b/docs/howtos/configurable-dependency.rst
@@ -13,6 +13,8 @@ based on parameters, or only slightly change their behavior.
   Note: :code:`configurable_dependency` decorator is optional, but it caches dependencies,
   so they results can be cached on injection.
 
+  Also, :code:`configurable_dependency` decorator does not cache dependencies configured with mutable arguments.
+
 Composite dependencies
 ======================
 Composite dependencies - special kind of configurable dependency that accepts other

--- a/docs/howtos/configurable-dependency.rst
+++ b/docs/howtos/configurable-dependency.rst
@@ -1,0 +1,21 @@
+********************************
+Configurable dependency(factory)
+********************************
+
+FunDI supports dependency factories - functions that return other dependencies,
+they are called Configurable dependencies. They can create completely different dependencies
+based on parameters, or only slightly change their behavior.
+
+.. literalinclude:: ../../examples/configurable_dependency.py
+
+..
+
+  Note: :code:`configurable_dependency` decorator is optional, but it caches dependencies,
+  so they results can be cached on injection.
+
+Composite dependencies
+======================
+Composite dependencies - special kind of configurable dependency that accepts other
+dependencies as parameters
+
+.. literalinclude:: ../../examples/composite_dependency.py

--- a/docs/howtos/index.rst
+++ b/docs/howtos/index.rst
@@ -26,6 +26,7 @@ Deep dive to each component
 
     dependency
     lifespan-dependency
+    configurable-dependency
     dependant
     scope
     injection

--- a/examples/composite_dependency.py
+++ b/examples/composite_dependency.py
@@ -1,0 +1,30 @@
+import typing
+from contextlib import ExitStack
+
+from fundi import from_, scan, inject, configurable_dependency
+
+
+def require_user() -> dict[str, str | tuple[str]]:
+    return {"username": "Kuyugama", "permissions": ("catch-apple",)}
+
+
+@configurable_dependency
+def require_permission(
+    permission: str,
+    user_resolver: typing.Callable[..., typing.Mapping[str, str | tuple[str]]] = require_user,
+):
+    def checker(user: typing.Mapping[str, str | tuple[str]] = from_(user_resolver)) -> None:
+        if permission not in user["permissions"]:
+            raise PermissionError(permission)
+
+    return checker
+
+
+def application(
+    _=from_(require_permission("catch-apple")),
+):
+    print("User has permission")
+
+
+with ExitStack() as stack:
+    inject({}, scan(application), stack)

--- a/examples/configurable_dependency.py
+++ b/examples/configurable_dependency.py
@@ -1,0 +1,27 @@
+import typing
+from contextlib import ExitStack
+
+from fundi import from_, scan, inject, configurable_dependency
+
+
+def require_user() -> typing.Mapping[str, str | tuple[str]]:
+    return {"username": "Kuyugama", "permissions": ("catch-apple",)}
+
+
+@configurable_dependency
+def require_permission(permission: str):
+    def checker(user: typing.Mapping[str, str | tuple[str]] = from_(require_user)) -> None:
+        if permission not in user["permissions"]:
+            raise PermissionError(permission)
+
+    return checker
+
+
+def application(
+    _=from_(require_permission("catch-apple")),
+):
+    print("User has permission")
+
+
+with ExitStack() as stack:
+    inject({}, scan(application), stack)

--- a/fundi/__init__.py
+++ b/fundi/__init__.py
@@ -4,5 +4,5 @@ from . import exceptions
 from .resolve import resolve
 from .inject import inject, ainject
 from .util import tree, order, injection_trace
-from .configurable import configurable_dependency
 from .types import CallableInfo, TypeResolver, InjectionTrace
+from .configurable import configurable_dependency, MutableConfigurationWarning

--- a/fundi/__init__.py
+++ b/fundi/__init__.py
@@ -4,4 +4,5 @@ from . import exceptions
 from .resolve import resolve
 from .inject import inject, ainject
 from .util import tree, order, injection_trace
+from .configurable import configurable_dependency
 from .types import CallableInfo, TypeResolver, InjectionTrace

--- a/fundi/configurable.py
+++ b/fundi/configurable.py
@@ -1,0 +1,44 @@
+import typing
+import warnings
+import functools
+
+from fundi.types import R
+from fundi.scan import scan
+from fundi.util import _callable_str
+
+P = typing.ParamSpec("P")
+
+
+def configurable_dependency(configurator: typing.Callable[P, R]) -> typing.Callable[P, R]:
+    dependencies: dict[tuple[tuple, frozenset], R] = {}
+    info = scan(configurator)
+
+    if info.async_:
+        raise ValueError("Dependency configurator should not be asynchronous")
+
+    @functools.wraps(configurator)
+    def cached_dependency_generator(*args: typing.Any, **kwargs: typing.Any) -> R:
+        use_cache = True
+        key = (args, frozenset(kwargs.items()))
+
+        try:
+            hash(key)
+        except TypeError:
+            warnings.warn(
+                f"Can't cache dependency created via {_callable_str(configurator)}: configured with unhashable arguments",
+                UserWarning,
+            )
+            use_cache = False
+
+        if use_cache and key in dependencies:
+            return dependencies[key]
+
+        dependency = configurator(*args, **kwargs)
+        setattr(dependency, "__fundi_configuration__", (args, kwargs))
+
+        if use_cache:
+            dependencies[key] = dependency
+
+        return dependency
+
+    return cached_dependency_generator

--- a/fundi/configurable.py
+++ b/fundi/configurable.py
@@ -9,7 +9,20 @@ from fundi.util import _callable_str
 P = typing.ParamSpec("P")
 
 
+class MutableConfigurationWarning(UserWarning):
+    pass
+
+
 def configurable_dependency(configurator: typing.Callable[P, R]) -> typing.Callable[P, R]:
+    """
+    Create dependency configurator that caches configured dependencies.
+    This helps FunDI cache resolver understand that dependency already executed, if it was.
+
+    Note: Calls with mutable arguments will not be stored in cache and warning would be shown
+
+    :param configurator: Original dependency configurator
+    :return: cache aware dependency configurator
+    """
     dependencies: dict[tuple[tuple, frozenset], R] = {}
     info = scan(configurator)
 
@@ -26,7 +39,7 @@ def configurable_dependency(configurator: typing.Callable[P, R]) -> typing.Calla
         except TypeError:
             warnings.warn(
                 f"Can't cache dependency created via {_callable_str(configurator)}: configured with unhashable arguments",
-                UserWarning,
+                MutableConfigurationWarning,
             )
             use_cache = False
 

--- a/tests/test_configurable_dependency.py
+++ b/tests/test_configurable_dependency.py
@@ -1,6 +1,6 @@
 import warnings
 
-from fundi import configurable_dependency
+from fundi import configurable_dependency, MutableConfigurationWarning
 
 
 def test_configurable_dependency_caching():
@@ -31,5 +31,5 @@ def test_configurable_dependency_mutable_argument():
         assert factory(["permissions"]) is not factory(["permissions"])
 
     assert got_warnings
-    assert got_warnings[0].category is UserWarning
+    assert got_warnings[0].category is MutableConfigurationWarning
 

--- a/tests/test_configurable_dependency.py
+++ b/tests/test_configurable_dependency.py
@@ -1,0 +1,35 @@
+import warnings
+
+from fundi import configurable_dependency
+
+
+def test_configurable_dependency_caching():
+    @configurable_dependency
+    def factory(require_admin: bool = False):
+        def checker(): ...
+
+        return checker
+
+
+    assert factory() is factory()
+    assert factory(require_admin=True) is not factory()
+    assert factory(require_admin=False) is not factory()
+    assert factory(require_admin=True) is factory(require_admin=True)
+    assert factory(require_admin=False) is factory(require_admin=False)
+
+
+def test_configurable_dependency_mutable_argument():
+    @configurable_dependency
+    def factory(permissions: list[str]):
+        def checker(): ...
+
+        return checker
+
+    assert factory(("permissions",)) is factory(("permissions",))
+
+    with warnings.catch_warnings(record=True) as got_warnings:
+        assert factory(["permissions"]) is not factory(["permissions"])
+
+    assert got_warnings
+    assert got_warnings[0].category is UserWarning
+


### PR DESCRIPTION
This PR improves documentation by introducing the concept of **configurable dependencies**(a.k.a. **dependency factories**).
This gives end users a powerful and explicit code pattern for building parameterized dependencies.

In addition, it adds a new decorator: `configurable_dependency` decorator. It provides:
- Caching of configured dependencies (when arguments are hashable),
- Validation (e.g., guards against async configurators),
- A lower chance of users accidentally shooting themselves in the foot with weird edge cases.

