### PR TITLE
Add dependency parameter awarenes

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -39,6 +39,13 @@ Library provides injection scope, that allows to inject values to dependencies p
 
 .. literalinclude:: ../examples/scope.py
 
+Dependency parameter awareness
+==============================
+Dependant's dependencies know of the parameter they are injected to.
+This can be used to create more transparent dependencies:
+
+ .. literalinclude:: ../examples/dependency_param_awareness.py
+
 
 Scope by type
 =============

--- a/docs/howtos/injection.rst
+++ b/docs/howtos/injection.rst
@@ -88,19 +88,47 @@ Example of injection that produces value:
     The same works with asynchronous injection
 
 
+Dependency parameter awareness
+==============================
+Sometimes dependencies need to know *where* they are being injected.
+
+With **dependency parameter awareness**, FunDI makes the `fundi.Parameter`
+object of the target parameter available for any dependency that declares:
+
+.. code-block:: python
+
+    from fundi import FromType, Parameter
+
+    def dependency(param: FromType[Parameter]):
+        print(param.name)        # name of the parameter being injected to
+        print(param.annotation)  # expected type of the parameter
+        ...
+
+This allows you to build smarter and more reusable dependencies, such as:
+
+- Automatically inferring names (e.g. :code:`user_id: int = from_header()` → :code:`X-User-Id` from parameter name)
+- Performing type conversion or validation based on annotation
+
+Example
+-------
+
+ .. literalinclude:: ../../examples/dependency_param_awareness.py
+
 Summary
 =======
 
-+--------------------------+--------------------+------------------------+
-| Feature                  | :code:`inject`     | :code:`ainject`        |
-+==========================+====================+========================+
-| Sync dependencies only   | Yes                | Yes                    |
-+--------------------------+--------------------+------------------------+
-| Async dependencies       | No                 | Yes                    |
-+--------------------------+--------------------+------------------------+
-| Mixed (sync + async)     | No                 | Yes                    |
-+--------------------------+--------------------+------------------------+
-| Requires stack           | :code:`ExitStack`  | :code:`AsyncExitStack` |
-+--------------------------+--------------------+------------------------+
-| Returns value            | Yes                | Yes                    |
-+--------------------------+--------------------+------------------------+
++--------------------------------+--------------------+------------------------+
+| Feature                        | :code:`inject`     | :code:`ainject`        |
++================================+====================+========================+
+| Sync dependencies only         | Yes                | Yes                    |
++--------------------------------+--------------------+------------------------+
+| Async dependencies             | No                 | Yes                    |
++--------------------------------+--------------------+------------------------+
+| Mixed (sync + async)           | No                 | Yes                    |
++--------------------------------+--------------------+------------------------+
+| Requires stack                 | :code:`ExitStack`  | :code:`AsyncExitStack` |
++--------------------------------+--------------------+------------------------+
+| Dependency parameter awareness | Yes                | Yes                    |
++--------------------------------+--------------------+------------------------+
+| Returns value                  | Yes                | Yes                    |
++--------------------------------+--------------------+------------------------+

--- a/examples/dependency_param_awareness.py
+++ b/examples/dependency_param_awareness.py
@@ -1,0 +1,23 @@
+from contextlib import ExitStack
+
+from fundi import scan, FromType, from_, inject, Parameter
+
+
+def header(param: FromType[Parameter]) -> str:
+    print("Parameter name:", param.name)
+    print("Parameter annotation:", param.annotation)
+
+    assert param.name == "token"
+    assert param.annotation is str
+
+    return f"{param.name}-{param.annotation!r}"
+
+
+def application(token: str = from_(header)):
+    print("Token:", token)
+
+    assert token == f"token-{str!r}"
+
+
+with ExitStack() as stack:
+    inject({}, scan(application), stack)

--- a/fundi/__init__.py
+++ b/fundi/__init__.py
@@ -6,7 +6,7 @@ from .from_ import from_
 from .resolve import resolve
 from .inject import inject, ainject
 from .util import tree, order, injection_trace
-from .types import CallableInfo, TypeResolver, InjectionTrace, R
+from .types import CallableInfo, TypeResolver, InjectionTrace, R, Parameter
 from .configurable import configurable_dependency, MutableConfigurationWarning
 
 

--- a/fundi/inject.py
+++ b/fundi/inject.py
@@ -32,13 +32,19 @@ def inject(
     values = {}
     try:
         for result in resolve(scope, info, cache, override):
-            name = result.parameter_name
+            name = result.parameter.name
             value = result.value
 
             if not result.resolved:
                 dependency = result.dependency
 
-                value = inject(scope, dependency, stack, cache, override)
+                value = inject(
+                    {**scope, "__fundi_parameter__": result.parameter},
+                    dependency,
+                    stack,
+                    cache,
+                    override,
+                )
 
                 if dependency.use_cache:
                     cache[dependency.call] = value
@@ -76,13 +82,19 @@ async def ainject(
 
     try:
         for result in resolve(scope, info, cache, override):
-            name = result.parameter_name
+            name = result.parameter.name
             value = result.value
 
             if not result.resolved:
                 dependency = result.dependency
 
-                value = await ainject(scope, dependency, stack, cache, override)
+                value = await ainject(
+                    {**scope, "__fundi_parameter__": result.parameter},
+                    dependency,
+                    stack,
+                    cache,
+                    override,
+                )
 
                 if dependency.use_cache:
                     cache[dependency.call] = value

--- a/fundi/types.py
+++ b/fundi/types.py
@@ -39,7 +39,7 @@ class CallableInfo(typing.Generic[R]):
 
 @dataclass
 class ParameterResult:
-    parameter_name: str
+    parameter: Parameter
     value: typing.Any | None
     dependency: CallableInfo | None
     resolved: bool

--- a/fundi/util.py
+++ b/fundi/util.py
@@ -53,7 +53,9 @@ def _call_sync(
         value = next(generator)
 
         def close_generator(
-            exc_type: type[BaseException] | None, exc_value: BaseException | None, tb: TracebackType | None
+            exc_type: type[BaseException] | None,
+            exc_value: BaseException | None,
+            tb: TracebackType | None,
         ) -> bool:
             try:
                 if exc_type is not None:
@@ -98,7 +100,9 @@ async def _call_async(
         value = await anext(generator)
 
         async def close_generator(
-            exc_type: type[BaseException] | None, exc_value: BaseException | None, tb: TracebackType | None
+            exc_type: type[BaseException] | None,
+            exc_value: BaseException | None,
+            tb: TracebackType | None,
         ) -> bool:
             try:
                 if exc_type is not None:
@@ -160,7 +164,7 @@ def tree(
     values = {}
 
     for result in resolve(scope, info, cache):
-        name = result.parameter_name
+        name = result.parameter.name
         value = result.value
 
         if not result.resolved:

--- a/tests/inject/test_inject.py
+++ b/tests/inject/test_inject.py
@@ -1,7 +1,7 @@
 from contextlib import ExitStack, AsyncExitStack
 
 from fundi.types import InjectionTrace
-from fundi import from_, scan, inject, ainject, injection_trace
+from fundi import from_, scan, inject, ainject, injection_trace, Parameter, FromType
 
 
 def test_inject_sync():
@@ -169,3 +169,18 @@ def test_generator_exception_awareness():
         assert False  # This should never happen
 
     assert dependency_state == "failed"
+
+
+def test_dependency_parameter_awareness():
+    def dep(param: FromType[Parameter]) -> str:
+        assert param.name == "arg"
+        assert param.annotation is str
+
+        return "value"
+
+    def func(arg: str = from_(dep)):
+        assert arg == "value"
+
+
+    with ExitStack() as stack:
+        inject({}, scan(func), stack)

--- a/tests/util/test_resolve.py
+++ b/tests/util/test_resolve.py
@@ -14,12 +14,12 @@ def test_resolve_sync():
             assert result.dependency.call is dep
 
         if result.resolved:
-            assert result.parameter_name in ("arg", "arg1")
+            assert result.parameter.name in ("arg", "arg1")
 
-            if result.parameter_name == "arg1":
+            if result.parameter.name == "arg1":
                 assert result.value == "value"
 
-            if result.parameter_name == "arg":
+            if result.parameter.name == "arg":
                 assert result.value == 1
 
 
@@ -36,12 +36,12 @@ def test_resolve_async():
             assert result.dependency.call is dep
 
         if result.resolved:
-            assert result.parameter_name in ("arg", "arg1")
+            assert result.parameter.name in ("arg", "arg1")
 
-            if result.parameter_name == "arg1":
+            if result.parameter.name == "arg1":
                 assert result.value == "value"
 
-            if result.parameter_name == "arg":
+            if result.parameter.name == "arg":
                 assert result.value == 1
 
 
@@ -59,15 +59,15 @@ def test_resolve_by_type():
     event_handler = EventHandler()
 
     for result in resolve({"arg": 1, "arg1": "value", "+1": event_handler}, scan(func), {}):
-        assert result.parameter_name in ("arg", "arg1", "handler")
+        assert result.parameter.name in ("arg", "arg1", "handler")
 
-        if result.parameter_name == "arg1":
+        if result.parameter.name == "arg1":
             assert result.value == "value"
 
-        if result.parameter_name == "arg":
+        if result.parameter.name == "arg":
             assert result.value == 1
 
-        if result.parameter_name == "handler":
+        if result.parameter.name == "handler":
             assert result.value is event_handler
 
 
@@ -86,15 +86,15 @@ def test_resolve_by_type_using_FromType():
     event_handler = EventHandler()
 
     for result in resolve({"arg": 1, "arg1": "value", "+1": event_handler}, scan(func), {}):
-        assert result.parameter_name in ("arg", "arg1", "handler")
+        assert result.parameter.name in ("arg", "arg1", "handler")
 
-        if result.parameter_name == "arg1":
+        if result.parameter.name == "arg1":
             assert result.value == "value"
 
-        if result.parameter_name == "arg":
+        if result.parameter.name == "arg":
             assert result.value == 1
 
-        if result.parameter_name == "handler":
+        if result.parameter.name == "handler":
             assert result.value is event_handler
 
 
@@ -104,7 +104,7 @@ def test_override_result():
     def func(arg: int = from_(dep)): ...
 
     for result in resolve({}, scan(func), {}, override={dep: 2}):
-        assert result.parameter_name == "arg"
+        assert result.parameter.name == "arg"
 
         assert result.value == 2
 
@@ -117,7 +117,7 @@ def test_override_dependency():
     def func(arg: int = from_(dep)): ...
 
     for result in resolve({}, scan(func), {}, override={dep: scan(test_dep)}):
-        assert result.parameter_name == "arg"
+        assert result.parameter.name == "arg"
 
         assert result.resolved is False
 


### PR DESCRIPTION
Dependency parameter awareness - dependant's dependencies know of the parameter where they are injected.

```python
import os
from fundi import Parameter, FromType, from_

def environ(param: FromType[Parameter]):
    return os.environ.get(param.name)


def application(api_token: str = from_(environ, caching=False)):
    print("API token:", api_token)
```