### PR TITLE
Satisfy basedpyright, move debug functions to own their module, add more public API

### DIFF
--- a/fundi/__init__.py
+++ b/fundi/__init__.py
@@ -1,8 +1,8 @@
 import typing as _typing
 
 from .scan import scan
-from . import exceptions
 from .from_ import from_
+from . import exceptions
 from .resolve import resolve
 from .debug import tree, order
 from .util import injection_trace

--- a/fundi/__init__.py
+++ b/fundi/__init__.py
@@ -4,8 +4,9 @@ from .scan import scan
 from . import exceptions
 from .from_ import from_
 from .resolve import resolve
+from .debug import tree, order
+from .util import injection_trace
 from .inject import inject, ainject
-from .util import tree, order, injection_trace
 from .types import CallableInfo, TypeResolver, InjectionTrace, R, Parameter
 from .configurable import configurable_dependency, MutableConfigurationWarning
 

--- a/fundi/configurable.py
+++ b/fundi/configurable.py
@@ -4,7 +4,7 @@ import functools
 
 from fundi.types import R
 from fundi.scan import scan
-from fundi.util import _callable_str
+from fundi.util import callable_str
 
 P = typing.ParamSpec("P")
 
@@ -38,7 +38,7 @@ def configurable_dependency(configurator: typing.Callable[P, R]) -> typing.Calla
             hash(key)
         except TypeError:
             warnings.warn(
-                f"Can't cache dependency created via {_callable_str(configurator)}: configured with unhashable arguments",
+                f"Can't cache dependency created via {callable_str(configurator)}: configured with unhashable arguments",
                 MutableConfigurationWarning,
             )
             use_cache = False

--- a/fundi/configurable.py
+++ b/fundi/configurable.py
@@ -23,7 +23,7 @@ def configurable_dependency(configurator: typing.Callable[P, R]) -> typing.Calla
     :param configurator: Original dependency configurator
     :return: cache aware dependency configurator
     """
-    dependencies: dict[tuple[tuple, frozenset], R] = {}
+    dependencies: dict[tuple[tuple[typing.Any, ...], frozenset[tuple[str, typing.Any]]], R] = {}
     info = scan(configurator)
 
     if info.async_:

--- a/fundi/debug.py
+++ b/fundi/debug.py
@@ -1,0 +1,82 @@
+import typing
+import collections.abc
+
+from fundi.resolve import resolve
+from fundi.types import CallableInfo
+
+
+def tree(
+    scope: collections.abc.Mapping[str, typing.Any],
+    info: CallableInfo[typing.Any],
+    cache: (
+        collections.abc.MutableMapping[
+            typing.Callable[..., typing.Any], collections.abc.Mapping[str, typing.Any]
+        ]
+        | None
+    ) = None,
+) -> collections.abc.Mapping[str, typing.Any]:
+    """
+    Get tree of dependencies of callable.
+
+    :param scope: container with contextual values
+    :param info: callable information
+    :param cache: tree generation cache
+    :return: Tree of dependencies
+    """
+    if cache is None:
+        cache = {}
+
+    values = {}
+
+    for result in resolve(scope, info, cache):
+        name = result.parameter.name
+        value = result.value
+
+        if not result.resolved:
+            dependency = result.dependency
+            assert dependency is not None
+            value = tree({**scope, "__fundi_parameter__": result.parameter}, dependency, cache)
+
+            if dependency.use_cache:
+                cache[dependency.call] = value
+
+        values[name] = value
+
+    return {"call": info.call, "values": values}
+
+
+def order(
+    scope: collections.abc.Mapping[str, typing.Any],
+    info: CallableInfo[typing.Any],
+    cache: (
+        collections.abc.MutableMapping[
+            typing.Callable[..., typing.Any], list[typing.Callable[..., typing.Any]]
+        ]
+        | None
+    ) = None,
+) -> list[typing.Callable[..., typing.Any]]:
+    """
+    Get resolving order of callable dependencies.
+
+    :param info: callable information
+    :param scope: container with contextual values
+    :param cache: solvation cache
+    :return: order of dependencies
+    """
+    if cache is None:
+        cache = {}
+
+    order_: list[typing.Callable[..., typing.Any]] = []
+
+    for result in resolve(scope, info, cache):
+        if not result.resolved:
+            assert result.dependency is not None
+
+            value = order(scope, result.dependency, cache)
+            order_.extend(value)
+            order_.append(result.dependency.call)
+
+            if result.dependency.use_cache:
+                cache[result.dependency.call] = value
+
+    return order_

--- a/fundi/exceptions.py
+++ b/fundi/exceptions.py
@@ -1,3 +1,4 @@
+from fundi.util import callable_str
 from fundi.types import CallableInfo
 from fundi.util import _callable_str
 
@@ -5,7 +6,7 @@ from fundi.util import _callable_str
 class ScopeValueNotFoundError(ValueError):
     def __init__(self, parameter: str, info: CallableInfo):
         super().__init__(
-            f'Cannot resolve "{parameter}" for {_callable_str(info.call)} - Scope does not contain required value'
+            f'Cannot resolve "{parameter}" for {callable_str(info.call)} - Scope does not contain required value'
         )
         self.parameter = parameter
         self.info = info

--- a/fundi/exceptions.py
+++ b/fundi/exceptions.py
@@ -1,12 +1,13 @@
+import typing
+
 from fundi.util import callable_str
 from fundi.types import CallableInfo
-from fundi.util import _callable_str
 
 
 class ScopeValueNotFoundError(ValueError):
-    def __init__(self, parameter: str, info: CallableInfo):
+    def __init__(self, parameter: str, info: CallableInfo[typing.Any]):
         super().__init__(
             f'Cannot resolve "{parameter}" for {callable_str(info.call)} - Scope does not contain required value'
         )
-        self.parameter = parameter
-        self.info = info
+        self.parameter: str = parameter
+        self.info: CallableInfo[typing.Any] = info

--- a/fundi/from_.py
+++ b/fundi/from_.py
@@ -1,12 +1,12 @@
 import typing
 
 from fundi.scan import scan
-from fundi.types import CallableInfo, TypeResolver, R
+from fundi.types import CallableInfo, TypeResolver
 
 
 def from_(
     dependency: type | typing.Callable[..., typing.Any], caching: bool = True
-) -> TypeResolver | CallableInfo:
+) -> TypeResolver | CallableInfo[typing.Any]:
     """
     Use callable or type as dependency for parameter of function
 

--- a/fundi/from_.pyi
+++ b/fundi/from_.pyi
@@ -1,5 +1,6 @@
 import typing
 from typing import overload
+from collections.abc import Generator, AsyncGenerator, Awaitable
 
 T = typing.TypeVar("T", bound=type)
 R = typing.TypeVar("R")
@@ -8,13 +9,11 @@ R = typing.TypeVar("R")
 def from_(dependency: T, caching: bool = True) -> T: ...
 @overload
 def from_(
-    dependency: typing.Callable[..., typing.Generator[R, None, None]], caching: bool = True
+    dependency: typing.Callable[..., Generator[R, None, None]], caching: bool = True
 ) -> R: ...
 @overload
-def from_(
-    dependency: typing.Callable[..., typing.AsyncGenerator[R, None]], caching: bool = True
-) -> R: ...
+def from_(dependency: typing.Callable[..., AsyncGenerator[R, None]], caching: bool = True) -> R: ...
 @overload
-def from_(dependency: typing.Callable[..., typing.Awaitable[R]], caching: bool = True) -> R: ...
+def from_(dependency: typing.Callable[..., Awaitable[R]], caching: bool = True) -> R: ...
 @overload
 def from_(dependency: typing.Callable[..., R], caching: bool = True) -> R: ...

--- a/fundi/inject.py
+++ b/fundi/inject.py
@@ -3,7 +3,7 @@ from contextlib import ExitStack, AsyncExitStack
 
 from fundi.resolve import resolve
 from fundi.types import CallableInfo
-from fundi.util import _call_sync, _call_async, _add_injection_trace
+from fundi.util import call_sync, call_async, add_injection_trace
 
 
 def inject(
@@ -52,10 +52,10 @@ def inject(
 
             values[name] = value
 
-        return _call_sync(stack, info, values)
+        return call_sync(stack, info, values)
 
     except Exception as exc:
-        _add_injection_trace(exc, info, values)
+        add_injection_trace(exc, info, values)
         raise exc
 
 
@@ -104,9 +104,9 @@ async def ainject(
             values[name] = value
 
         if not info.async_:
-            return _call_sync(stack, info, values)
+            return call_sync(stack, info, values)
 
-        return await _call_async(stack, info, values)
+        return await call_async(stack, info, values)
     except Exception as exc:
-        _add_injection_trace(exc, info, values)
+        add_injection_trace(exc, info, values)
         raise exc

--- a/fundi/inject.py
+++ b/fundi/inject.py
@@ -1,4 +1,5 @@
 import typing
+import collections.abc
 from contextlib import ExitStack, AsyncExitStack
 
 from fundi.resolve import resolve
@@ -7,11 +8,13 @@ from fundi.util import call_sync, call_async, add_injection_trace
 
 
 def inject(
-    scope: typing.Mapping[str, typing.Any],
+    scope: collections.abc.Mapping[str, typing.Any],
     info: CallableInfo[typing.Any],
     stack: ExitStack,
-    cache: typing.MutableMapping[typing.Callable, typing.Any] | None = None,
-    override: typing.Mapping[typing.Callable, typing.Any] | None = None,
+    cache: (
+        collections.abc.MutableMapping[typing.Callable[..., typing.Any], typing.Any] | None
+    ) = None,
+    override: collections.abc.Mapping[typing.Callable[..., typing.Any], typing.Any] | None = None,
 ) -> typing.Any:
     """
     Synchronously inject dependencies into callable.
@@ -29,7 +32,7 @@ def inject(
     if cache is None:
         cache = {}
 
-    values = {}
+    values: dict[str, typing.Any] = {}
     try:
         for result in resolve(scope, info, cache, override):
             name = result.parameter.name
@@ -60,11 +63,13 @@ def inject(
 
 
 async def ainject(
-    scope: typing.Mapping[str, typing.Any],
+    scope: collections.abc.Mapping[str, typing.Any],
     info: CallableInfo[typing.Any],
     stack: AsyncExitStack,
-    cache: typing.MutableMapping[typing.Callable, typing.Any] | None = None,
-    override: typing.Mapping[typing.Callable, typing.Any] | None = None,
+    cache: (
+        collections.abc.MutableMapping[typing.Callable[..., typing.Any], typing.Any] | None
+    ) = None,
+    override: collections.abc.Mapping[typing.Callable[..., typing.Any], typing.Any] | None = None,
 ) -> typing.Any:
     """
     Asynchronously inject dependencies into callable.
@@ -79,7 +84,7 @@ async def ainject(
     if cache is None:
         cache = {}
 
-    values = {}
+    values: dict[str, typing.Any] = {}
 
     try:
         for result in resolve(scope, info, cache, override):

--- a/fundi/inject.pyi
+++ b/fundi/inject.pyi
@@ -1,6 +1,7 @@
 import typing
 from typing import overload
 from contextlib import ExitStack as SyncExitStack, AsyncExitStack
+from collections.abc import Generator, AsyncGenerator, Mapping, Awaitable
 
 from fundi.types import CallableInfo
 
@@ -10,49 +11,49 @@ ExitStack = AsyncExitStack | SyncExitStack
 
 @overload
 def inject(
-    scope: typing.Mapping[str, typing.Any],
-    info: CallableInfo[typing.Generator[R, None, None]],
+    scope: Mapping[str, typing.Any],
+    info: CallableInfo[Generator[R, None, None]],
     stack: ExitStack,
-    cache: typing.Mapping[typing.Callable, typing.Any] | None = None,
-    override: typing.Mapping[typing.Callable, typing.Any] | None = None,
+    cache: Mapping[typing.Callable[..., typing.Any], typing.Any] | None = None,
+    override: Mapping[typing.Callable[..., typing.Any], typing.Any] | None = None,
 ) -> R: ...
 @overload
 def inject(
-    scope: typing.Mapping[str, typing.Any],
+    scope: Mapping[str, typing.Any],
     info: CallableInfo[R],
     stack: ExitStack,
-    cache: typing.Mapping[typing.Callable, typing.Any] | None = None,
-    override: typing.Mapping[typing.Callable, typing.Any] | None = None,
+    cache: Mapping[typing.Callable[..., typing.Any], typing.Any] | None = None,
+    override: Mapping[typing.Callable[..., typing.Any], typing.Any] | None = None,
 ) -> R: ...
 @overload
 async def ainject(
-    scope: typing.Mapping[str, typing.Any],
-    info: CallableInfo[typing.Generator[R, None, None]],
+    scope: Mapping[str, typing.Any],
+    info: CallableInfo[Generator[R, None, None]],
     stack: AsyncExitStack,
-    cache: typing.Mapping[typing.Callable, typing.Any] | None = None,
-    override: typing.Mapping[typing.Callable, typing.Any] | None = None,
+    cache: Mapping[typing.Callable[..., typing.Any], typing.Any] | None = None,
+    override: Mapping[typing.Callable[..., typing.Any], typing.Any] | None = None,
 ) -> R: ...
 @overload
 async def ainject(
-    scope: typing.Mapping[str, typing.Any],
-    info: CallableInfo[typing.AsyncGenerator[R, None]],
+    scope: Mapping[str, typing.Any],
+    info: CallableInfo[AsyncGenerator[R, None]],
     stack: AsyncExitStack,
-    cache: typing.Mapping[typing.Callable, typing.Any] | None = None,
-    override: typing.Mapping[typing.Callable, typing.Any] | None = None,
+    cache: Mapping[typing.Callable[..., typing.Any], typing.Any] | None = None,
+    override: Mapping[typing.Callable[..., typing.Any], typing.Any] | None = None,
 ) -> R: ...
 @overload
 async def ainject(
-    scope: typing.Mapping[str, typing.Any],
-    info: CallableInfo[typing.Awaitable[R]],
+    scope: Mapping[str, typing.Any],
+    info: CallableInfo[Awaitable[R]],
     stack: AsyncExitStack,
-    cache: typing.Mapping[typing.Callable, typing.Any] | None = None,
-    override: typing.Mapping[typing.Callable, typing.Any] | None = None,
+    cache: Mapping[typing.Callable[..., typing.Any], typing.Any] | None = None,
+    override: Mapping[typing.Callable[..., typing.Any], typing.Any] | None = None,
 ) -> R: ...
 @overload
 async def ainject(
-    scope: typing.Mapping[str, typing.Any],
+    scope: Mapping[str, typing.Any],
     info: CallableInfo[R],
     stack: AsyncExitStack,
-    cache: typing.Mapping[typing.Callable, typing.Any] | None = None,
-    override: typing.Mapping[typing.Callable, typing.Any] | None = None,
+    cache: Mapping[typing.Callable[..., typing.Any], typing.Any] | None = None,
+    override: Mapping[typing.Callable[..., typing.Any], typing.Any] | None = None,
 ) -> R: ...

--- a/fundi/resolve.py
+++ b/fundi/resolve.py
@@ -1,12 +1,14 @@
+import types
 import typing
+import collections.abc
 
 from fundi.types import CallableInfo, ParameterResult, Parameter
 
 
 def resolve_by_dependency(
     param: Parameter,
-    cache: typing.Mapping[typing.Callable, typing.Any],
-    override: typing.Mapping[typing.Callable, typing.Any],
+    cache: collections.abc.Mapping[typing.Callable[..., typing.Any], typing.Any],
+    override: collections.abc.Mapping[typing.Callable[..., typing.Any], typing.Any],
 ) -> ParameterResult:
     dependency = param.from_
 
@@ -15,7 +17,7 @@ def resolve_by_dependency(
     value = override.get(dependency.call)
     if value is not None:
         if isinstance(value, CallableInfo):
-            return ParameterResult(param, None, value, resolved=False)
+            return ParameterResult(param, None, dependency, resolved=False)
 
         return ParameterResult(param, value, dependency, resolved=True)
 
@@ -25,13 +27,15 @@ def resolve_by_dependency(
     return ParameterResult(param, None, dependency, resolved=False)
 
 
-def resolve_by_type(scope: typing.Mapping[str, typing.Any], param: Parameter) -> ParameterResult:
+def resolve_by_type(
+    scope: collections.abc.Mapping[str, typing.Any], param: Parameter
+) -> ParameterResult:
     annotation = param.annotation
 
     type_options = (annotation,)
 
     origin = typing.get_origin(annotation)
-    if origin is typing.Union:
+    if origin is types.UnionType:
         type_options = tuple(t for t in typing.get_args(annotation) if t is not None)
     elif origin is not None:
         type_options = (origin,)
@@ -46,11 +50,11 @@ def resolve_by_type(scope: typing.Mapping[str, typing.Any], param: Parameter) ->
 
 
 def resolve(
-    scope: typing.Mapping[str, typing.Any],
-    info: CallableInfo,
-    cache: typing.Mapping[typing.Callable, typing.Any],
-    override: typing.Mapping[typing.Callable, typing.Any] | None = None,
-) -> typing.Generator[ParameterResult, None, None]:
+    scope: collections.abc.Mapping[str, typing.Any],
+    info: CallableInfo[typing.Any],
+    cache: collections.abc.Mapping[typing.Callable[..., typing.Any], typing.Any],
+    override: collections.abc.Mapping[typing.Callable[..., typing.Any], typing.Any] | None = None,
+) -> collections.abc.Generator[ParameterResult, None, None]:
     """
     Try to resolve values from cache or scope for callable parameters
 

--- a/fundi/resolve.py
+++ b/fundi/resolve.py
@@ -17,7 +17,9 @@ def resolve_by_dependency(
     value = override.get(dependency.call)
     if value is not None:
         if isinstance(value, CallableInfo):
-            return ParameterResult(param, None, dependency, resolved=False)
+            return ParameterResult(
+                param, None, typing.cast(CallableInfo[typing.Any], value), resolved=False
+            )
 
         return ParameterResult(param, value, dependency, resolved=True)
 

--- a/fundi/types.py
+++ b/fundi/types.py
@@ -1,4 +1,6 @@
 import typing
+import collections
+import collections.abc
 from dataclasses import dataclass
 
 __all__ = ["R", "TypeResolver", "Parameter", "CallableInfo", "ParameterResult", "InjectionTrace"]
@@ -22,7 +24,7 @@ class TypeResolver:
 class Parameter:
     name: str
     annotation: type
-    from_: "CallableInfo | None"
+    from_: "CallableInfo[typing.Any] | None"
     default: typing.Any = None
     has_default: bool = False
     resolve_by_type: bool = False
@@ -30,7 +32,7 @@ class Parameter:
 
 @dataclass
 class CallableInfo(typing.Generic[R]):
-    call: typing.Callable[..., typing.Any]
+    call: typing.Callable[..., R]
     use_cache: bool
     async_: bool
     generator: bool
@@ -41,12 +43,12 @@ class CallableInfo(typing.Generic[R]):
 class ParameterResult:
     parameter: Parameter
     value: typing.Any | None
-    dependency: CallableInfo | None
+    dependency: CallableInfo[typing.Any] | None
     resolved: bool
 
 
 @dataclass
 class InjectionTrace:
-    info: CallableInfo
-    values: typing.Mapping[str, typing.Any]
+    info: CallableInfo[typing.Any]
+    values: collections.abc.Mapping[str, typing.Any]
     origin: "InjectionTrace | None" = None

--- a/fundi/util.py
+++ b/fundi/util.py
@@ -1,6 +1,7 @@
 import typing
 import inspect
 import warnings
+import collections.abc
 from types import TracebackType
 from contextlib import AsyncExitStack, ExitStack
 
@@ -31,8 +32,10 @@ def callable_str(call: typing.Callable[..., typing.Any]) -> str:
     return f"<{name} from {module_name}>"
 
 
-    exception: Exception, info: CallableInfo, values: typing.Mapping[str, typing.Any]
 def add_injection_trace(
+    exception: Exception,
+    info: CallableInfo[typing.Any],
+    values: collections.abc.Mapping[str, typing.Any],
 ) -> None:
     setattr(
         exception,
@@ -44,7 +47,7 @@ def add_injection_trace(
 def call_sync(
     stack: ExitStack | AsyncExitStack,
     info: CallableInfo[typing.Any],
-    values: typing.Mapping[str, typing.Any],
+    values: collections.abc.Mapping[str, typing.Any],
 ) -> typing.Any:
     """
     Synchronously call dependency callable.
@@ -57,7 +60,7 @@ def call_sync(
     value = info.call(**values)
 
     if info.generator:
-        generator: typing.Generator = value
+        generator: collections.abc.Generator[typing.Any, None, None] = value
         value = next(generator)
 
         def close_generator(
@@ -90,8 +93,10 @@ def call_sync(
     return value
 
 
-    stack: AsyncExitStack, info: CallableInfo[typing.Any], values: typing.Mapping[str, typing.Any]
 async def call_async(
+    stack: AsyncExitStack,
+    info: CallableInfo[typing.Any],
+    values: collections.abc.Mapping[str, typing.Any],
 ) -> typing.Any:
     """
     Asynchronously call dependency callable.
@@ -104,7 +109,7 @@ async def call_async(
     value = info.call(**values)
 
     if info.generator:
-        generator: typing.AsyncGenerator = value
+        generator: collections.abc.AsyncGenerator[typing.Any] = value
         value = await anext(generator)
 
         async def close_generator(

--- a/fundi/util.py
+++ b/fundi/util.py
@@ -8,15 +8,15 @@ from fundi.types import CallableInfo, InjectionTrace
 
 
 __all__ = [
-    "_call_sync",
-    "_call_async",
-    "_callable_str",
+    "call_sync",
+    "call_async",
+    "callable_str",
     "injection_trace",
-    "_add_injection_trace",
+    "add_injection_trace",
 ]
 
 
-def _callable_str(call: typing.Callable) -> str:
+def callable_str(call: typing.Callable[..., typing.Any]) -> str:
     if hasattr(call, "__qualname__"):
         name = call.__qualname__
     elif hasattr(call, "__name__"):
@@ -31,8 +31,8 @@ def _callable_str(call: typing.Callable) -> str:
     return f"<{name} from {module_name}>"
 
 
-def _add_injection_trace(
     exception: Exception, info: CallableInfo, values: typing.Mapping[str, typing.Any]
+def add_injection_trace(
 ) -> None:
     setattr(
         exception,
@@ -41,7 +41,7 @@ def _add_injection_trace(
     )
 
 
-def _call_sync(
+def call_sync(
     stack: ExitStack | AsyncExitStack,
     info: CallableInfo[typing.Any],
     values: typing.Mapping[str, typing.Any],
@@ -90,8 +90,8 @@ def _call_sync(
     return value
 
 
-async def _call_async(
     stack: AsyncExitStack, info: CallableInfo[typing.Any], values: typing.Mapping[str, typing.Any]
+async def call_async(
 ) -> typing.Any:
     """
     Asynchronously call dependency callable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,8 @@ filterwarnings = [
     "ignore::DeprecationWarning"
 ]
 
+[tool.pyright]
+reportAny = false
+reportUnusedCallResult = false
+exclude = [".venv"]
+


### PR DESCRIPTION
This PR makes FunDI more readable and useful.

Changes:
- `tree` and `order` functions are moved to their own (`fundi.debug`) module
- `_call_sync`, `_call_async`, `_callable_str`, `_add_injection_trace` functions are now public (removed "`_`" prefix)
- All issues with basedpyright are fixed now