### PR TITLE
Add normalize_annotation utility function

### DIFF
--- a/fundi/__init__.py
+++ b/fundi/__init__.py
@@ -6,8 +6,8 @@ from . import exceptions
 from .resolve import resolve
 from .debug import tree, order
 from .inject import inject, ainject
-from .util import injection_trace, is_configured, get_configuration
 from .configurable import configurable_dependency, MutableConfigurationWarning
+from .util import injection_trace, is_configured, get_configuration, normalize_annotation
 from .types import CallableInfo, TypeResolver, InjectionTrace, R, Parameter, DependencyConfiguration
 
 
@@ -30,6 +30,7 @@ __all__ = [
     "InjectionTrace",
     "injection_trace",
     "get_configuration",
+    "normalize_annotation",
     "DependencyConfiguration",
     "configurable_dependency",
     "MutableConfigurationWarning",

--- a/fundi/resolve.py
+++ b/fundi/resolve.py
@@ -1,7 +1,7 @@
-import types
 import typing
 import collections.abc
 
+from fundi.util import normalize_annotation
 from fundi.types import CallableInfo, ParameterResult, Parameter
 
 
@@ -32,23 +32,7 @@ def resolve_by_dependency(
 def resolve_by_type(
     scope: collections.abc.Mapping[str, typing.Any], param: Parameter
 ) -> ParameterResult:
-    annotation = param.annotation
-
-    type_options = (annotation,)
-
-    origin = typing.get_origin(annotation)
-    args = typing.get_args(annotation)
-
-    if origin is typing.Annotated:
-        annotation = args[0]
-        type_options = (annotation,)
-        origin = typing.get_origin(annotation)
-        args = typing.get_args(annotation)
-
-    if origin is types.UnionType:
-        type_options = tuple(t for t in args if t is not None)
-    elif origin is not None:
-        type_options = (origin,)
+    type_options = normalize_annotation(param.annotation)
 
     for value in scope.values():
         if not isinstance(value, type_options):

--- a/fundi/util.py
+++ b/fundi/util.py
@@ -1,3 +1,4 @@
+import types
 import typing
 import inspect
 import warnings
@@ -16,6 +17,7 @@ __all__ = [
     "injection_trace",
     "get_configuration",
     "add_injection_trace",
+    "normalize_annotation",
 ]
 
 
@@ -185,3 +187,26 @@ def get_configuration(call: typing.Callable[..., typing.Any]) -> DependencyConfi
 
     configuration: DependencyConfiguration = getattr(call, "__fundi_configuration__")
     return configuration
+
+
+def normalize_annotation(annotation: typing.Any) -> tuple[type[typing.Any], ...]:
+    """
+    Normalize type annotation to make it easily work with
+    """
+    type_options: tuple[type, ...] = (annotation,)
+
+    origin = typing.get_origin(annotation)
+    args = typing.get_args(annotation)
+
+    if origin is typing.Annotated:
+        annotation = args[0]
+        type_options = (annotation,)
+        origin = typing.get_origin(annotation)
+        args = typing.get_args(annotation)
+
+    if origin is types.UnionType:
+        type_options = tuple(t for t in args if t is not types.NoneType)
+    elif origin is not None:
+        type_options = (origin,)
+
+    return type_options


### PR DESCRIPTION
This PR separates logic for normalization annotations from `fundi.resolve.resolve_by_type` function